### PR TITLE
Release/0.1.1 beta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ log = "0.4"
 simple_logger = "1.11.0"
 prettytable-rs = "0.8.0"
 tui = { version = "0.16.0", features = ["crossterm"]}
-tokio = { version = "0.2", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = { version = "0.7.3", default-features = false, features = ["std"] }
 thiserror = "1.0"

--- a/src/command/hoard_command.rs
+++ b/src/command/hoard_command.rs
@@ -58,6 +58,23 @@ impl HoardCommand {
         }
     }
 
+    pub fn with_tags_raw(self, tags: String) -> Self {
+        Self {
+            name: self.name,
+            namespace: self.namespace,
+            tags: Some(
+                tags.chars()
+                    .filter(|c| !c.is_whitespace())
+                    .collect::<String>()
+                    .split(',')
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
+            command: self.command,
+            description: self.description,
+        }
+    }
+
     pub fn with_tags_input(self) -> Self {
         let tags: String = Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Give your command tags ( comma separated )")
@@ -72,13 +89,7 @@ impl HoardCommand {
             })
             .interact_text()
             .unwrap();
-        Self {
-            name: self.name,
-            namespace: self.namespace,
-            tags: Some(tags.split(',').map(|s| s.to_string()).collect()),
-            command: self.command,
-            description: self.description,
-        }
+        self.with_tags_raw(tags)
     }
 
     pub fn with_namespace_input(self) -> Self {
@@ -157,5 +168,59 @@ impl Parsable for HoardCommand {
             new_command.command = c.to_string();
         }
         new_command
+    }
+}
+
+#[cfg(test)]
+mod test_commands {
+    use super::*;
+
+    #[test]
+    fn one_tag_as_string() {
+        let command = HoardCommand::default().with_tags_raw(String::from("foo"));
+        let expected = "foo";
+        assert_eq!(expected, command.tags_as_string());
+    }
+
+    #[test]
+    fn no_tag_as_string() {
+        let command = HoardCommand::default();
+        let expected = "";
+        assert_eq!(expected, command.tags_as_string());
+    }
+
+    #[test]
+    fn multiple_tags_as_string() {
+        let command = HoardCommand::default().with_tags_raw(String::from("foo,bar"));
+        let expected = "foo,bar";
+        assert_eq!(expected, command.tags_as_string());
+    }
+
+    #[test]
+    fn parse_single_tag() {
+        let command = HoardCommand::default().with_tags_raw(String::from("foo"));
+        let expected = Some(vec![String::from("foo")]);
+        assert_eq!(expected, command.tags);
+    }
+
+    #[test]
+    fn parse_no_tag() {
+        let command = HoardCommand::default();
+        let expected = None;
+        assert_eq!(expected, command.tags);
+    }
+
+    #[test]
+    fn parse_multiple_tags() {
+        let command = HoardCommand::default().with_tags_raw(String::from("foo,bar"));
+        let expected = Some(vec![String::from("foo"), String::from("bar")]);
+        assert_eq!(expected, command.tags);
+    }
+
+    #[test]
+    fn parse_whitespace_in_tags() {
+        let command = HoardCommand::default().with_tags_raw(String::from("foo, bar"));
+        let expected = Some(vec![String::from("foo"), String::from("bar")]);
+        assert_eq!(expected, command.tags);
     }
 }

--- a/src/command/hoard_command.rs
+++ b/src/command/hoard_command.rs
@@ -36,9 +36,12 @@ impl HoardCommand {
         }
         true
     }
-    
+
     pub fn tags_as_string(&self) -> String {
-        self.tags.as_ref().unwrap_or(&vec![String::from("")]).join(",")
+        self.tags
+            .as_ref()
+            .unwrap_or(&vec![String::from("")])
+            .join(",")
     }
 
     pub fn with_command_string_input(self) -> Self {

--- a/src/command/trove.rs
+++ b/src/command/trove.rs
@@ -50,8 +50,7 @@ impl CommandTrove {
     }
 
     pub fn pick_command(&self, name: String) -> Result<HoardCommand> {
-        let filtered_command: Option<&HoardCommand> =
-            self.commands.iter().find(|c| c.name == name);
+        let filtered_command: Option<&HoardCommand> = self.commands.iter().find(|c| c.name == name);
         if let Some(command) = filtered_command {
             Ok(command.clone())
         } else {

--- a/src/command/trove.rs
+++ b/src/command/trove.rs
@@ -49,6 +49,16 @@ impl CommandTrove {
         self.commands.push(new_command);
     }
 
+    pub fn remove_command(&mut self, name: String) -> Result<(),anyhow::Error> {
+        let command_position = self.commands.iter().position(|x| x.name == name);
+        if command_position.is_none() {
+            return Err(anyhow!("Command not found [{}]", name));
+        } else {
+            self.commands.retain(|x| *x.name != name);
+            Ok(())
+        }
+    }
+
     pub fn pick_command(&self, name: String) -> Result<HoardCommand> {
         let filtered_command: Option<&HoardCommand> = self.commands.iter().find(|c| c.name == name);
         if let Some(command) = filtered_command {

--- a/src/command/trove.rs
+++ b/src/command/trove.rs
@@ -49,7 +49,7 @@ impl CommandTrove {
         self.commands.push(new_command);
     }
 
-    pub fn remove_command(&mut self, name: String) -> Result<(),anyhow::Error> {
+    pub fn remove_command(&mut self, name: String) -> Result<(), anyhow::Error> {
         let command_position = self.commands.iter().position(|x| x.name == name);
         if command_position.is_none() {
             return Err(anyhow!("Command not found [{}]", name));

--- a/src/gui/commands_gui.rs
+++ b/src/gui/commands_gui.rs
@@ -13,9 +13,7 @@ use tui::{
     layout::{Alignment, Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     text::{Span, Spans},
-    widgets::{
-        Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Tabs, Wrap
-    },
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Tabs, Wrap},
     Terminal,
 };
 
@@ -75,7 +73,7 @@ pub fn run(trove: &mut CommandTrove) -> Result<(), Box<dyn std::error::Error>> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
-    
+
     //let menu_titles = vec!["List", "Search", "Add", "Delete", "Quit"];
     let menu_titles = vec!["List", "Quit"];
     let active_menu_item = MenuItem::List;
@@ -122,20 +120,24 @@ pub fn run(trove: &mut CommandTrove) -> Result<(), Box<dyn std::error::Error>> {
                 .divider(Span::raw("|"));
 
             rect.render_widget(tabs, chunks[0]);
-            
+
             let commands_chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints(
-                            [Constraint::Percentage(20), Constraint::Percentage(80)].as_ref(),
-                        )
-                        .split(chunks[1]);
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(20), Constraint::Percentage(80)].as_ref())
+                .split(chunks[1]);
             let command_detail_chunks = Layout::default()
-                        .direction(Direction::Vertical)
-                        .constraints(
-                            [Constraint::Percentage(30), Constraint::Percentage(30), Constraint::Percentage(40)].as_ref(),
-                        )
-                        .split(commands_chunks[1]);
-            let (commands, command, namespace, tags, description) = render_commands(trove.commands.clone(), &command_list_state);
+                .direction(Direction::Vertical)
+                .constraints(
+                    [
+                        Constraint::Percentage(30),
+                        Constraint::Percentage(30),
+                        Constraint::Percentage(40),
+                    ]
+                    .as_ref(),
+                )
+                .split(commands_chunks[1]);
+            let (commands, command, namespace, tags, description) =
+                render_commands(trove.commands.clone(), &command_list_state);
             rect.render_stateful_widget(commands, commands_chunks[0], &mut command_list_state);
             rect.render_widget(namespace, command_detail_chunks[0]);
             rect.render_widget(tags, command_detail_chunks[1]);
@@ -178,7 +180,16 @@ pub fn run(trove: &mut CommandTrove) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn render_commands<'a>(commands_list: Vec<HoardCommand>, command_list_state: &ListState) -> (List<'a>, Paragraph<'a>, Paragraph<'a>, Paragraph<'a>, Paragraph<'a>) {
+fn render_commands<'a>(
+    commands_list: Vec<HoardCommand>,
+    command_list_state: &ListState,
+) -> (
+    List<'a>,
+    Paragraph<'a>,
+    Paragraph<'a>,
+    Paragraph<'a>,
+    Paragraph<'a>,
+) {
     let commands = Block::default()
         .borders(Borders::ALL)
         .style(Style::default().fg(Color::White))
@@ -212,49 +223,49 @@ fn render_commands<'a>(commands_list: Vec<HoardCommand>, command_list_state: &Li
     );
 
     let command = Paragraph::new(selected_command.command.clone())
-    .style(Style::default().fg(Color::LightCyan))
-    .alignment(Alignment::Center)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .style(Style::default().fg(Color::White))
-            .title("Hoarded command")
-            .border_type(BorderType::Plain),
-    );
+        .style(Style::default().fg(Color::LightCyan))
+        .alignment(Alignment::Center)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(Color::White))
+                .title("Hoarded command")
+                .border_type(BorderType::Plain),
+        );
 
     let namespace = Paragraph::new(selected_command.namespace.clone())
-    .style(Style::default().fg(Color::White))
-    .alignment(Alignment::Left)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .style(Style::default().fg(Color::White))
-            .title("Namespace")
-            .border_type(BorderType::Plain),
-    );
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Left)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(Color::White))
+                .title("Namespace")
+                .border_type(BorderType::Plain),
+        );
 
     let tags = Paragraph::new(selected_command.tags_as_string())
-    .style(Style::default().fg(Color::White))
-    .alignment(Alignment::Left)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .style(Style::default().fg(Color::White))
-            .title("Tags")
-            .border_type(BorderType::Plain),
-    );
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Left)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(Color::White))
+                .title("Tags")
+                .border_type(BorderType::Plain),
+        );
 
     let description = Paragraph::new(selected_command.description.unwrap_or_default())
-    .style(Style::default().fg(Color::White))
-    .alignment(Alignment::Left)
-    .wrap(Wrap { trim: true })
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .style(Style::default().fg(Color::White))
-            .title("Description")
-            .border_type(BorderType::Plain),
-    );
+        .style(Style::default().fg(Color::White))
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: true })
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .style(Style::default().fg(Color::White))
+                .title("Description")
+                .border_type(BorderType::Plain),
+        );
 
     (list, command, namespace, tags, description)
 }

--- a/src/hoard.rs
+++ b/src/hoard.rs
@@ -1,6 +1,7 @@
 use clap::{load_yaml, App};
 use log::info;
 
+
 use crate::config::load_or_build_config;
 
 use super::command::hoard_command::HoardCommand;
@@ -105,6 +106,19 @@ impl Hoard {
                         }
                         Err(e) => eprintln!("{}", e),
                     }
+                }
+            }
+            // removes command from trove with a name supplied by input
+            ("remove", Some(sub_m)) => {
+                if let Some(command_name) = sub_m.value_of("name") {
+                    let command_result = self.trove.remove_command(command_name.into());
+                    match command_result {
+                        Ok(_) => {
+                            println!("Removed [{}]", command_name);
+                        }
+                        Err(e) => eprintln!("{}", e),
+                    }
+                    self.save_trove();
                 }
             }
             // Load command by name

--- a/src/hoard.rs
+++ b/src/hoard.rs
@@ -1,7 +1,6 @@
 use clap::{load_yaml, App};
 use log::info;
 
-
 use crate::config::load_or_build_config;
 
 use super::command::hoard_command::HoardCommand;

--- a/src/hoard.rs
+++ b/src/hoard.rs
@@ -1,7 +1,7 @@
 use clap::{load_yaml, App};
-use log::{info};
+use log::info;
 
-use crate::{config::load_or_build_config};
+use crate::config::load_or_build_config;
 
 use super::command::hoard_command::HoardCommand;
 use super::command::trove::CommandTrove;
@@ -51,7 +51,6 @@ impl Hoard {
         self
     }
 
-
     pub fn save_trove(&self) {
         match &self.config {
             Some(config) => self
@@ -65,7 +64,6 @@ impl Hoard {
         let yaml = load_yaml!("resources/cli.yaml");
         let matches = App::from(yaml).get_matches();
 
-
         if let Some(matches) = matches.subcommand_matches("test") {
             if matches.is_present("debug") {
                 println!("Printing debug info...");
@@ -73,7 +71,7 @@ impl Hoard {
                 println!("Printing normally...");
             }
         }
-    
+
         match matches.subcommand() {
             // Create new command and save it it in trove
             ("new", Some(_sub_m)) => {
@@ -100,7 +98,8 @@ impl Hoard {
             // Load command by name into clipboard, if available
             ("pick", Some(sub_m)) => {
                 if let Some(command_name) = sub_m.value_of("name") {
-                    let command_result = self.trove.pick_command(command_name.into()); match command_result {
+                    let command_result = self.trove.pick_command(command_name.into());
+                    match command_result {
                         Ok(c) => {
                             println!("{}", c.command)
                         }

--- a/src/resources/cli.yaml
+++ b/src/resources/cli.yaml
@@ -71,3 +71,14 @@ subcommands:
                 help: Name of the command
                 required: true
                 takes_value: true
+    - remove:
+        short: r
+        help: Removes a command of the trove
+        version: "0.1"
+        args: 
+            - name: 
+                long: name
+                short: n
+                help: Name of the command
+                required: true
+                takes_value: true


### PR DESCRIPTION
- Add `remove` subcommand. Removes a command from the trove. Name has to be equal to the command's hoarded name to be removed