### PR TITLE
🔨 Move hoard home path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const HOARD_HOMEDIR: &str = ".config/.hoard";
+const HOARD_HOMEDIR: &str = ".config/hoard";
 const HOARD_FILE: &str = "trove.yml";
 const HOARD_CONFIG: &str = "config.yml";
 


### PR DESCRIPTION
Move hoard config and trove file to `~/.config/hoard` from `~/.config/.hoard` to match how every other program is doing it
fixes #68