### PR TITLE
🚀 Make tags optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - ✨ Customizable GUI colors through ~/config/.hoard/config.yml
 - ✨ Support parameterized commands. Put '#' in place where a parameter is expected. When running `hoard pick <command_name>` or `hoard list` as a shell plugin and selecting a parameterized command, `hoard` will ask for all missing parameters to input before sending the complete command to your shell input. 
 - ✨ Press `<F1>` when running `hoard list` to see all shortcuts
+- ✨ Make tags optional
 
 Breaking changes:
 - 🔨 Find your hoard config files at `~/.config/hoard` (Used to be `~/.config/.hoard`. Copy them over or import your old trove file by running `hoard import ~/.config/.hoard/trove.yml`)

--- a/src/command/hoard_command.rs
+++ b/src/command/hoard_command.rs
@@ -66,7 +66,7 @@ impl HoardCommand {
             "Command to hoard ( Mark unknown parameters with {} )\n",
             parameter_token
         );
-        let command_string: String = prompt_input(&base_prompt, default_value);
+        let command_string: String = prompt_input(&base_prompt, false, default_value);
         Self {
             name: self.name,
             namespace: self.namespace,
@@ -102,7 +102,8 @@ impl HoardCommand {
             }
         };
         let tags: String = prompt_input_validate(
-            "Give your command some tags ( comma seperated )",
+            "Give your command some optional tags ( comma seperated )",
+            true,
             default_value,
             Some(tag_validator),
         );
@@ -110,7 +111,7 @@ impl HoardCommand {
     }
 
     pub fn with_namespace_input(self, default_namespace: Option<String>) -> Self {
-        let namespace: String = prompt_input("Namespace of the command", default_namespace);
+        let namespace: String = prompt_input("Namespace of the command", false, default_namespace);
         Self {
             name: self.name,
             namespace,
@@ -144,7 +145,7 @@ impl HoardCommand {
                 Ok(())
             }
         };
-        let name = prompt_input_validate(prompt_string, default_value, Some(validator));
+        let name = prompt_input_validate(prompt_string, false, default_value, Some(validator));
         Self {
             name,
             namespace: self.namespace,
@@ -176,7 +177,7 @@ impl HoardCommand {
 
     pub fn with_description_input(self, default_value: Option<String>) -> Self {
         let description_string: String =
-            prompt_input("Describe what the command does", default_value);
+            prompt_input("Describe what the command does", false, default_value);
         Self {
             name: self.name,
             namespace: self.namespace,
@@ -283,7 +284,7 @@ impl Parameterized for HoardCommand {
                 (i + 1),
                 command_state
             );
-            let parameter = prompt_input(&prompt_dialoge, None);
+            let parameter = prompt_input(&prompt_dialoge, false, None);
             command_state = command_state.replacen(token, &parameter, 1);
         }
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ impl HoardConfig {
     pub fn with_default_namespace(self) -> Self {
         let default_namespace = prompt_input(
             "This is the first time running hoard.\nChoose a default namespace where you want to hoard your commands.",
+            false,
             Some("default".to_string())
         );
         Self {

--- a/src/gui/prompts.rs
+++ b/src/gui/prompts.rs
@@ -48,10 +48,11 @@ pub fn prompt_yes_or_no(text: &str) -> Confirmation {
     }
 }
 
-pub fn prompt_input(text: &str, default_value: Option<String>) -> String {
+pub fn prompt_input(text: &str, allow_empty: bool, default_value: Option<String>) -> String {
     // Just calls `prompt_input_validate` to not keep on typing `None` for the validator
     prompt_input_validate(
         text,
+        allow_empty,
         default_value,
         None::<Box<dyn FnMut(&String) -> Result<(), String>>>,
     )
@@ -59,6 +60,7 @@ pub fn prompt_input(text: &str, default_value: Option<String>) -> String {
 
 pub fn prompt_input_validate<F>(
     text: &str,
+    allow_empty: bool,
     default_value: Option<String>,
     validator: Option<F>,
 ) -> String
@@ -75,6 +77,7 @@ where
     if let Some(val) = validator {
         input.validate_with(val);
     }
+    input.allow_empty(allow_empty);
     input.with_prompt(text).interact_text().unwrap()
 }
 


### PR DESCRIPTION
When creating new command with `hoard new`, make prompt for `tags` optional