### PR TITLE
update Readme.md about trove

### DIFF
--- a/example_troves/Readme.md
+++ b/example_troves/Readme.md
@@ -4,11 +4,11 @@ List of trove files, showing how `hoard` can be used
 
 To import one of the trove files run 
 ```
-hoard import https://github.com/Hyde46/tree/main/example_troves/<trove_name>.yml
+hoard import https://raw.githubusercontent.com/Hyde46/hoard/main/example_troves/<trove_name>.yml
 ```
 
 ### Git trove
 Super simple git trove example
 ```
-hoard import https://github.com/Hyde46/tree/main/example_troves/git.yml
+hoard import https://raw.githubusercontent.com/Hyde46/hoard/main/example_troves/git.yml
 ```


### PR DESCRIPTION
This PR fixes Readme.md about trove.

`https://github.com/Hyde46/tree/main/example_troves/git.yml` is not found, so I rewritten to be able to  install.

```bash
❯ hoard import https://github.com/Hyde46/tree/main/example_troves/git.yml
The supplied trove file is invalid!
Message("invalid type: string \"Not Found\", expected struct CommandTrove", Some(Pos { marker: Marker { index: 0, line: 1, col: 0 }, path: "." }))
```


Thank you in advance.