### PR TITLE
Create all directories if they do not exist

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ fn load_or_build(path: &Path) -> Result<HoardConfig, Error> {
     let hoard_dir = home_path.join(HOARD_HOMEDIR);
     if !hoard_dir.exists() {
         info!("Creating {:?}", hoard_dir);
-        fs::create_dir(&hoard_dir)?;
+        fs::create_dir_all(&hoard_dir)?;
     }
 
     let hoard_config_path = hoard_dir.join(HOARD_CONFIG);


### PR DESCRIPTION
This PR replaces `create_dir` with `create_dir_all`.


## Why

If the `.config/` directory does not exist, an OS Error will occur when the hoard creates the configuration.
To deal with this problem, we need to use create_dir_all, which can create all directories.

```bash
❯ ./target/debug/hoard list
ERROR: No such file or directory (os error 2)
```


## Ref
https://doc.rust-lang.org/std/fs/fn.create_dir.html
https://doc.rust-lang.org/std/fs/fn.create_dir_all.html



Thank you in advance.
