### PR TITLE
ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ Cargo.lock
 /hoard_*/
 
 /.vscode/
+**/.DS_Store


### PR DESCRIPTION
## What
ignore .DS_Store

## Why
.DS_Store is created and the difference is made on macOS


Thank you in advance.