### PR TITLE
Add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ If you are running `fish` shell
 LATEST_RELEASE=1.3.0 ./install.fish
 ```
 
+### AUR (Arch Linux)
+```
+paru -S hoard
+```
+
 ### Homebrew (macOS)
 ```
 brew tap Hyde46/hoard


### PR DESCRIPTION
Hello! I created the following packages for installing `hoard` on Arch Linux via AUR:

- https://aur.archlinux.org/packages/hoard
- https://aur.archlinux.org/packages/hoard-git
