### PR TITLE
chore(ci): build/test with `--locked` flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --locked --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --locked --verbose


### PR DESCRIPTION
This PR makes it possible to avoid lockfile related issues such as #283 early in the development cycle.

`--locked: Require Cargo.lock is up to date`
