### PR TITLE
chore: move from unmaintained tui -> ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags 1.3.2",
  "crossterm_winapi",
@@ -715,16 +715,16 @@ dependencies = [
  "log",
  "prettytable-rs",
  "rand",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
  "simple_logger",
  "tempfile",
- "termion 2.0.1",
+ "termion",
  "thiserror",
  "tokio",
- "tui",
  "url",
 ]
 
@@ -848,6 +848,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "instant"
@@ -1118,6 +1124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1219,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8285baa38bdc9f879d92c0e37cb562ef38aa3aeefca22b3200186bc39242d3d5"
+dependencies = [
+ "bitflags 2.3.3",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "paste",
+ "termion",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1593,18 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
-dependencies = [
- "libc",
- "numtoa",
- "redox_syscall",
- "redox_termios",
-]
-
-[[package]]
-name = "termion"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
@@ -1776,20 +1792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags 1.3.2",
- "cassowary",
- "crossterm",
- "termion 1.5.6",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ log = "0.4"
 eyre = "0.6"
 simple_logger = "4.1.0"
 prettytable-rs = "0.10.0"
-tui = { version = "0.19.0", features = ["termion"] }
+ratatui = { version = "0.22.0", features = ["termion"] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = { version = "0.8.4", features = ["std"] }
 thiserror = "1.0"

--- a/src/gui/commands_gui.rs
+++ b/src/gui/commands_gui.rs
@@ -18,7 +18,7 @@ use std::io::stdout;
 use std::time::Duration;
 use termion::raw::IntoRawMode;
 use termion::screen::IntoAlternateScreen;
-use tui::{backend::TermionBackend, widgets::ListState, Terminal};
+use ratatui::{backend::TermionBackend, widgets::ListState, Terminal};
 use crate::gpt::prompt;
 
 #[allow(clippy::struct_excessive_bools)]

--- a/src/gui/help.rs
+++ b/src/gui/help.rs
@@ -3,11 +3,11 @@ use crate::config::HoardConfig;
 use crate::gui::commands_gui::{DrawState, State};
 use termion::event::Key;
 use termion::screen::AlternateScreen;
-use tui::backend::TermionBackend;
-use tui::style::{Color, Style};
-use tui::text::{Span, Spans};
-use tui::widgets::{Block, BorderType, Borders, List, ListItem};
-use tui::Terminal;
+use ratatui::backend::TermionBackend;
+use ratatui::style::{Color, Style};
+use ratatui::text::{Span, Line};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem};
+use ratatui::Terminal;
 
 pub const HELP_KEY: &str = "<F1>";
 const HELP_CONTENT: &[(&str, &str)] = &[
@@ -50,7 +50,7 @@ pub fn draw(
             .iter()
             .map(|item| {
                 ListItem::new(vec![
-                    Spans::from(Span::styled(
+                    Line::from(Span::styled(
                         item.0,
                         Style::default().fg(Color::Rgb(
                             config.command_color.unwrap().0,
@@ -58,7 +58,7 @@ pub fn draw(
                             config.command_color.unwrap().2,
                         )),
                     )),
-                    Spans::from(Span::styled(
+                    Line::from(Span::styled(
                         format!("    {}", item.1),
                         Style::default().fg(Color::Rgb(
                             config.primary_color.unwrap().0,
@@ -66,7 +66,7 @@ pub fn draw(
                             config.primary_color.unwrap().2,
                         )),
                     )),
-                    Spans::from(""),
+                    Line::from(""),
                 ])
             })
             .collect();

--- a/src/gui/list_search/controls.rs
+++ b/src/gui/list_search/controls.rs
@@ -230,7 +230,7 @@ fn apply_filter(state: &mut State, namespaces: &[&str], commands: &[HoardCommand
 #[cfg(test)]
 mod test_controls {
     use super::*;
-    use tui::widgets::ListState;
+    use ratatui::widgets::ListState;
 
     const DEFAULT_NAMESPACE: &str = "default";
 

--- a/src/gui/list_search/render.rs
+++ b/src/gui/list_search/render.rs
@@ -4,12 +4,12 @@ use crate::gui::commands_gui::State;
 use crate::gui::commands_gui::{ControlState, EditSelection};
 use crate::gui::help::HELP_KEY;
 use termion::screen::AlternateScreen;
-use tui::backend::TermionBackend;
-use tui::layout::{Alignment, Constraint, Direction, Layout, Rect};
-use tui::style::{Color, Modifier, Style};
-use tui::text::{Span, Spans};
-use tui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Tabs, Wrap, Clear};
-use tui::Terminal;
+use ratatui::backend::TermionBackend;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Span, Line};
+use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Tabs, Wrap, Clear};
+use ratatui::Terminal;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -40,7 +40,7 @@ pub fn draw(
         let menu = namespace_tabs
             .iter()
             .map(|t| {
-                Spans::from(vec![Span::styled(
+                Line::from(vec![Span::styled(
                     *t,
                     Style::default().fg(Color::Rgb(
                         config.primary_color.unwrap().0,
@@ -198,7 +198,7 @@ fn get_color(
     app: &mut State,
     config: &HoardConfig,
     command_render: &EditSelection,
-) -> tui::style::Color {
+) -> ratatui::style::Color {
     let highlighted = Color::Rgb(
         config.secondary_color.unwrap().0,
         config.secondary_color.unwrap().1,
@@ -253,7 +253,7 @@ fn render_commands<'a>(
     let items: Vec<_> = commands_list
         .iter()
         .map(|command| {
-            ListItem::new(Spans::from(vec![Span::styled(
+            ListItem::new(Line::from(vec![Span::styled(
                 command.name.clone(),
                 Style::default(),
             )]))

--- a/src/gui/new_command/render.rs
+++ b/src/gui/new_command/render.rs
@@ -1,11 +1,11 @@
 use crate::config::HoardConfig;
 use crate::gui::commands_gui::State;
 use termion::screen::AlternateScreen;
-use tui::backend::TermionBackend;
-use tui::layout::{Constraint, Direction, Layout};
-use tui::style::{Color, Style};
-use tui::widgets::{Block, Paragraph};
-use tui::Terminal;
+use ratatui::backend::TermionBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Style};
+use ratatui::widgets::{Block, Paragraph};
+use ratatui::Terminal;
 
 pub fn draw(
     app_state: &mut State,

--- a/src/gui/parameter_input/render.rs
+++ b/src/gui/parameter_input/render.rs
@@ -2,12 +2,12 @@ use crate::config::HoardConfig;
 use crate::gui::commands_gui::State;
 use crate::util::{split_with_delim, string_find_next, translate_number_to_nth};
 use termion::screen::AlternateScreen;
-use tui::backend::TermionBackend;
-use tui::layout::{Alignment, Constraint, Direction, Layout};
-use tui::style::{Color, Style};
-use tui::text::{Span, Spans};
-use tui::widgets::{Block, Paragraph, Wrap};
-use tui::Terminal;
+use ratatui::backend::TermionBackend;
+use ratatui::layout::{Alignment, Constraint, Direction, Layout};
+use ratatui::style::{Color, Style};
+use ratatui::text::{Span, Line};
+use ratatui::widgets::{Block, Paragraph, Wrap};
+use ratatui::Terminal;
 
 pub fn draw(
     app_state: &mut State,
@@ -107,7 +107,7 @@ pub fn draw(
             command_spans.append(&mut spans);
         }
 
-        let command = Paragraph::new(Spans::from(command_spans))
+        let command = Paragraph::new(Line::from(command_spans))
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true })
             .block(Block::default().style(primary_style));


### PR DESCRIPTION
Replaces the unmaintained `tui` library with it's maintained fork `ratatui`.

https://github.com/fdehau/tui-rs/issues/709