### PR TITLE
Added `HOARD_CONFIG` env variable to specify config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "shellexpand",
  "simple_logger",
  "tempfile",
  "termion",
@@ -1108,7 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1783,6 +1784,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ chatgpt_blocking_rs = "0.1.2"
 dotenv = "0.15.0"
 h2 = "0.3.20"
 regex = "1.10.2"
+shellexpand = "3.1.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/core/trove.rs
+++ b/src/core/trove.rs
@@ -82,7 +82,11 @@ impl Trove {
                 }
             },
         );
-        trove.namespaces = trove.namespaces().into_iter().map(std::string::ToString::to_string).collect();
+        trove.namespaces = trove
+            .namespaces()
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         trove
     }
 
@@ -97,7 +101,11 @@ impl Trove {
                 Self::default()
             }
         };
-        trove.namespaces = trove.namespaces().into_iter().map(std::string::ToString::to_string).collect();
+        trove.namespaces = trove
+            .namespaces()
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         trove
     }
 
@@ -109,6 +117,7 @@ impl Trove {
     /// Save the trove collection to `path` as a yaml file
     pub fn save_trove_file(&self, path: &Path) {
         let s = self.to_yaml();
+        println!("Saving trove to {:?}", path);
         fs::write(path, s).expect("Unable to write config file");
     }
 
@@ -149,13 +158,13 @@ impl Trove {
     }
 
     /// Adds a command to trove file
-    /// 
+    ///
     /// Returns `true` if the command has been added
-    /// 
+    ///
     /// Returns `false` if the command has not been added due to a name collision that has been resolved where the trove did not change
-    /// 
+    ///
     /// if `overwrite_colliding` is set to true, the name of the command will get a random string suffix to resolve the name collision before adding it to the trove
-    /// 
+    ///
     /// if `overwrite_colliding` is set to false, the name collision will not be resolved and the command will not be added to the trove
     pub fn add_command(
         &mut self,
@@ -199,9 +208,9 @@ impl Trove {
     }
 
     /// Remove a command from the trove collection
-    /// 
+    ///
     /// Returns `Ok(())` if the command has been removed
-    /// 
+    ///
     /// Returns `Err(anyhow::Error)` if the command to remove is not in the trove
     pub fn remove_command(&mut self, name: &str) -> Result<(), anyhow::Error> {
         let command_position = self.commands.iter().position(|x| x.name == name);

--- a/src/hoard.rs
+++ b/src/hoard.rs
@@ -30,9 +30,9 @@ pub struct Hoard {
 }
 
 impl Hoard {
-    pub fn with_config(&mut self, hoard_home_path: Option<String>) -> &mut Self {
+    pub fn with_config(&mut self) -> &mut Self {
         info!("Loading config");
-        match load_or_build_config(hoard_home_path) {
+        match load_or_build_config() {
             Ok(config) => self.config = config,
             Err(err) => {
                 eprintln!("ERROR: {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,7 @@ use hoard::Hoard;
 
 #[tokio::main]
 async fn main() {
-    let (command, is_autocomplete) = Hoard::default()
-        .with_config(None)
-        .load_trove()
-        .start();
+    let (command, is_autocomplete) = Hoard::default().with_config().load_trove().start();
     if is_autocomplete {
         eprintln!("{}", command.trim());
     } else {


### PR DESCRIPTION
`HOARD_CONFIG` can point to a file path or a directory path where the file name would default to `config.yml`

```sh
export HOARD_CONFIG="~/.zsh/config/plugins/hoard_config.yml"
```


* Added `shellexpand` dependency.
* Expand tilde and variables for `trove_path` when reading `config.trove_path`
* Removed duplicate construction for `HoardConfig`.
* Added tests for reading env variable and making sure files are there.
* Split up reading path and creating files at paths.

Fixes: https://github.com/Hyde46/hoard/issues/346