### PR TITLE
Removing `config_home_path` from `HoardConfig`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,6 +868,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "shellexpand",
  "simple_logger",
  "tempfile",
  "termion",
@@ -1108,7 +1109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1783,6 +1784,15 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da03fa3b94cc19e3ebfc88c4229c49d8f08cdbd1228870a45f0ffdf84988e14b"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ chatgpt_blocking_rs = "0.1.2"
 dotenv = "0.15.0"
 h2 = "0.3.20"
 regex = "1.10.2"
+shellexpand = "3.1.0"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,6 @@ const ENV_HOARD_CONFIG_PATH: &str = "HOARD_CONFIG";
 pub struct HoardConfig {
     pub version: String,
     pub default_namespace: String,
-    pub config_home_path: Option<PathBuf>,
     pub trove_path: Option<PathBuf>,
     pub query_prefix: String,
     // Color settings
@@ -42,7 +41,6 @@ impl Default for HoardConfig {
         Self {
             version: VERSION.to_string(),
             default_namespace: "default".to_string(),
-            config_home_path: None,
             trove_path: None,
             query_prefix: "  >".to_string(),
             primary_color: Some(Self::default_colors(0)),
@@ -62,7 +60,6 @@ impl Default for HoardConfig {
 impl HoardConfig {
     pub fn new(hoard_home_path: &Path) -> Self {
         Self {
-            config_home_path: Some(hoard_home_path.to_path_buf()),
             trove_path: Some(hoard_home_path.join(DEFAULT_HOARD_FILE)),
             ..Self::default()
         }
@@ -298,8 +295,8 @@ fn save_config(config_to_save: &HoardConfig, config_path: &Path) -> Result<(), E
     Ok(())
 }
 
-pub fn save_hoard_config_file(config_to_save: &HoardConfig, base_path: &Path) -> Result<(), Error> {
-    let config_dir = base_path.join(DEFAULT_HOARD_CONFIG_FILE);
+pub fn save_hoard_config_file(config_to_save: &HoardConfig) -> Result<(), Error> {
+    let config_dir = get_hoard_config_path()?;
 
     save_config(config_to_save, &config_dir)
 }
@@ -374,10 +371,6 @@ mod test_config {
 
         env::set_var("HOARD_CONFIG", &tmp_path);
         let x = load_or_build_config().unwrap();
-        assert_eq!(
-            x.config_home_path.as_ref().unwrap(),
-            tmp_path.clone().parent().unwrap()
-        );
         let f = File::open(tmp_path).ok().unwrap();
         let parsed_config = serde_yaml::from_reader::<_, HoardConfig>(f).ok().unwrap();
         assert_eq!(parsed_config, x);
@@ -386,7 +379,6 @@ mod test_config {
 
         env::set_var("HOARD_CONFIG", &tmp_path);
         let x = load_or_build_config().unwrap();
-        assert_eq!(x.config_home_path.as_ref().unwrap(), tmp_path.as_path());
         let f = File::open(tmp_path.join(DEFAULT_HOARD_CONFIG_FILE))
             .ok()
             .unwrap();

--- a/src/core/trove.rs
+++ b/src/core/trove.rs
@@ -82,7 +82,11 @@ impl Trove {
                 }
             },
         );
-        trove.namespaces = trove.namespaces().into_iter().map(std::string::ToString::to_string).collect();
+        trove.namespaces = trove
+            .namespaces()
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         trove
     }
 
@@ -97,7 +101,11 @@ impl Trove {
                 Self::default()
             }
         };
-        trove.namespaces = trove.namespaces().into_iter().map(std::string::ToString::to_string).collect();
+        trove.namespaces = trove
+            .namespaces()
+            .into_iter()
+            .map(std::string::ToString::to_string)
+            .collect();
         trove
     }
 
@@ -109,6 +117,7 @@ impl Trove {
     /// Save the trove collection to `path` as a yaml file
     pub fn save_trove_file(&self, path: &Path) {
         let s = self.to_yaml();
+        println!("Saving trove to {:?}", path);
         fs::write(path, s).expect("Unable to write config file");
     }
 
@@ -149,13 +158,13 @@ impl Trove {
     }
 
     /// Adds a command to trove file
-    /// 
+    ///
     /// Returns `true` if the command has been added
-    /// 
+    ///
     /// Returns `false` if the command has not been added due to a name collision that has been resolved where the trove did not change
-    /// 
+    ///
     /// if `overwrite_colliding` is set to true, the name of the command will get a random string suffix to resolve the name collision before adding it to the trove
-    /// 
+    ///
     /// if `overwrite_colliding` is set to false, the name collision will not be resolved and the command will not be added to the trove
     pub fn add_command(
         &mut self,
@@ -199,9 +208,9 @@ impl Trove {
     }
 
     /// Remove a command from the trove collection
-    /// 
+    ///
     /// Returns `Ok(())` if the command has been removed
-    /// 
+    ///
     /// Returns `Err(anyhow::Error)` if the command to remove is not in the trove
     pub fn remove_command(&mut self, name: &str) -> Result<(), anyhow::Error> {
         let command_position = self.commands.iter().position(|x| x.name == name);

--- a/src/hoard.rs
+++ b/src/hoard.rs
@@ -30,9 +30,9 @@ pub struct Hoard {
 }
 
 impl Hoard {
-    pub fn with_config(&mut self, hoard_home_path: Option<String>) -> &mut Self {
+    pub fn with_config(&mut self) -> &mut Self {
         info!("Loading config");
-        match load_or_build_config(hoard_home_path) {
+        match load_or_build_config() {
             Ok(config) => self.config = config,
             Err(err) => {
                 eprintln!("ERROR: {err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,7 @@ use hoard::Hoard;
 
 #[tokio::main]
 async fn main() {
-    let (command, is_autocomplete) = Hoard::default()
-        .with_config(None)
-        .load_trove()
-        .start();
+    let (command, is_autocomplete) = Hoard::default().with_config().load_trove().start();
     if is_autocomplete {
         eprintln!("{}", command.trim());
     } else {


### PR DESCRIPTION
Removing `config_home_path` from `HoardConfig` because it should be computed. 
The file having a reference to its own path makes for undefined behaviour when switching it. 

Fix: https://github.com/Hyde46/hoard/issues/348
Depends on: https://github.com/Hyde46/hoard/pull/347