### PR TITLE
Support for Escape-Characters

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 **/.env
 
 **/.idea
+
+# No Nix-Direnv
+./.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "Rust-Flake by blckr";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      supportedSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShellNoCC {
+            buildInputs = with pkgs; [
+              rustc
+              cargo
+              gcc
+              rust-analyzer
+              rustfmt
+              clippy
+              gdb
+              openssl
+              openssl.dev
+            ];
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+            ];
+          };
+        }
+      );
+    };
+}

--- a/src/gui/parameter_input/controls.rs
+++ b/src/gui/parameter_input/controls.rs
@@ -12,20 +12,40 @@ pub fn key_handler(input: Key, app: &mut State) -> Option<HoardCmd> {
         }
         Key::Char('\n') => {
             let command = app.selected_command.clone().unwrap();
-            let parameter = app.input.clone();
+
+            let mut safe_parameter = app.input.clone();
+            safe_parameter = safe_parameter.replace(&app.parameter_token, "\u{E000}");
+            if !app.parameter_ending_token.is_empty() {
+                safe_parameter = safe_parameter.replace(&app.parameter_ending_token, "\u{E001}");
+            }
+
             let replaced_command = command.replace_parameter(
                 &app.parameter_token,
                 &app.parameter_ending_token,
-                &parameter,
+                &safe_parameter,
             );
+
             app.input = String::new();
+
             if replaced_command.get_parameter_count(&app.parameter_token) == 0 {
-                return Some(replaced_command);
+                let mut final_command = replaced_command
+                    .cleanup_escapes(&app.parameter_token, &app.parameter_ending_token);
+
+                let mut restored_cmd = final_command.command.clone();
+                restored_cmd = restored_cmd.replace('\u{E000}', &app.parameter_token);
+                if !app.parameter_ending_token.is_empty() {
+                    restored_cmd = restored_cmd.replace('\u{E001}', &app.parameter_ending_token);
+                }
+                final_command.command = restored_cmd;
+
+                return Some(final_command);
             }
+
             app.selected_command = Some(replaced_command);
             app.provided_parameter_count += 1;
             None
         }
+
         // Handle query input
         Key::Backspace => {
             app.input.pop();


### PR DESCRIPTION
We can now use ! # thanks to \! and \#. Also \\ is supported.
- Color-Support for correct highlighting has been expanded to support this feature
- Some new Testcases have been added

Added Support for Nix via a tailored flake.

This should solve issue [#200](https://github.com/Hyde46/hoard/issues/200)\